### PR TITLE
修改两处代码

### DIFF
--- a/src/OFDPage.cxx
+++ b/src/OFDPage.cxx
@@ -12,7 +12,7 @@ using namespace tinyxml2;
 using namespace ofd;
 
 OFDPage::OFDPage(OFDDocument *ofdDocument, uint64_t id, const std::string &filename)
-    : m_ofdDocument(ofdDocument), m_id(id), m_filename(filename) {
+    : m_ofdDocument(ofdDocument), m_id(id), m_filename(filename), m_opened(false) {
     m_attributes.clear();
 }
 


### PR DESCRIPTION
1. m_opened 初始化为false,不然运行时候m_opened 随机返回true
2. 调整读zip方式, 读内容长度>分配长度,咱们调用方式没有错误,  对比了长度不一样的内容只是从源文件某处开始多读了出来,我尝试其他的zip文件.用同样代码(也尝试其他一些flag),也有一些文件会出现读内容长度>分配长度,有些是正常.

修改了strlen(Content)代码,主要是遇到\0,长度计算错误, 所以我直接把读到内容append fileContent中.
修改了一次性分配文件长度内存,改成for循环每次读入100字节.
